### PR TITLE
chore: reduce tool cache size

### DIFF
--- a/.github/workflows/tool-cache.yml
+++ b/.github/workflows/tool-cache.yml
@@ -51,6 +51,7 @@ jobs:
       run: |
         pip install awscli
     - name: Publish tool cache to S3
+      if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
We're reducing the tool cache size to the actual tools we are now using as it takes quite some time to load the tool cache
