### PR TITLE
fix: allow passing of github token

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -86,4 +86,4 @@ jobs:
         renovate-image: ${{ inputs.renovate-image }}
         renovate-version: ${{ inputs.renovate-version }}
         token: '${{ steps.get_token.outputs.token }}'
-        env-regex: "^(?:RENOVATE_\\w+|GITHUB_TOKEN)$"
+        env-regex: "^(?:RENOVATE_\\w+|GITHUB_TOKEN|HARBOR_\\w+)$"


### PR DESCRIPTION
see: https://github.com/renovatebot/github-action?tab=readme-ov-file#environment-variables
by default env variables **not** prefixed with RENOVATE_ are not passed to internal docker container.