### PR TITLE
feat: add an action to fetch the commit sha for the current workflow run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,29 @@ jobs:
         expected: success
         actual: ${{ steps.check-workflow-status-required-files.outcome }}
 
+  test-commit-sha:
+    runs-on: kubernetes-runner
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+    - name: Get commit SHA
+      id: commit-sha
+      uses: ./commit-sha
+
+    - name: Assert commit SHA
+      uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      with:
+        expected: ${{ github.event.pull_request.head.sha || github.sha }}
+        actual: ${{ steps.commit-sha.outputs.sha }}
+
+    - name: Assert commit short SHA
+      uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      with:
+        expected: ${{ steps.commit-sha.outputs.short-sha }}
+        actual: ${{ steps.commit-sha.outputs.sha }}
+        comparison: 'startsWith'
+
   check-workflow-status:
     runs-on: kubernetes-runner
     permissions:
@@ -152,5 +175,5 @@ jobs:
       id: check-workflow-status
       uses: ./check-workflow-status
       with:
-        jobs: 'test-update-major-version-tag,test-check-workflow-status'
+        jobs: 'test-update-major-version-tag,test-check-workflow-status,test-commit-sha'
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains common GitHub Actions and shared workflows.
 The following GitHub Actions are available in this repository:
 
 - [check-workflow-status](check-workflow-status/README.md)
+- [commit-sha](commit-sha/README.md)
 - [update-major-version-tag](update-major-version-tag/README.md)
 
 <!-- END ACTIONS -->

--- a/commit-sha/README.md
+++ b/commit-sha/README.md
@@ -1,0 +1,26 @@
+<!-- NOTE: This file's contents are automatically generated. Do not edit manually. -->
+# Commit SHA (Action)
+
+Set the source commit SHA for a workflow as output variable. Regardless of whether the workflow is triggered by a push or a pull request, this action will provide the actual source commit SHA.
+
+## 🔧 Inputs
+
+|           Name          |          Description         |Required|Default|
+|-------------------------|------------------------------|--------|-------|
+|`commit-short-sha-length`|Length of the short commit SHA|   No   |  `7`  |
+
+## 📤 Outputs
+
+|    Name   |             Description             |
+|-----------|-------------------------------------|
+|   `sha`   | The commit SHA used as source commit|
+|`short-sha`|The short commit SHA as source commit|
+
+## 🚀 Usage
+
+```yaml
+- name: Commit SHA
+  uses: eidp/actions-common/commit-sha@v0
+  with:
+    # your inputs here
+```

--- a/commit-sha/action.yml
+++ b/commit-sha/action.yml
@@ -1,0 +1,33 @@
+name: 'Commit SHA'
+description: >
+  Set the source commit SHA for a workflow as output variable.
+  Regardless of whether the workflow is triggered by a push or a pull request, this action
+  will provide the actual source commit SHA.
+
+branding:
+  icon: 'git-branch'
+  color: 'yellow'
+inputs:
+  commit-short-sha-length:
+    description: 'Length of the short commit SHA'
+    required: false
+    default: '7'
+outputs:
+  sha:
+    description: 'The commit SHA used as source commit'
+    value: ${{ steps.set-commit-sha.outputs.commit-sha }}
+  short-sha:
+    description: 'The short commit SHA as source commit'
+    value: ${{ steps.set-commit-sha.outputs.commit-short-sha }}
+runs:
+  using: 'composite'
+  steps:
+  - name: Determine commit SHA
+    id: set-commit-sha
+    shell: bash
+    env:
+      COMMIT_SHORT_SHA_LENGTH: ${{ inputs.commit-short-sha-length }}
+    run: |
+      COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+      echo "commit-sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+      echo "commit-short-sha=${COMMIT_SHA:0:$COMMIT_SHORT_SHA_LENGTH}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
It either uses the github.sha or github.event.pull_request.head.sha so that we always have the actual source commit and not a weird commit that is generated by GitHub.
