### PR TITLE
feat: use dynamic job discovery for check-workflow-status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      pull-requests: read
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -80,43 +79,27 @@ jobs:
       working-directory: check-workflow-status
       run: python3 test_check_status.py
 
-    - name: check-workflow-status success
-      id: check-workflow-status-success
+    - name: Test check-workflow-status action can run
+      id: check-workflow-status-integration
       uses: ./check-workflow-status
       with:
-        jobs: 'test-update-major-version-tag'
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Assert Workflow Status
       uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
       with:
         expected: success
-        actual: ${{ steps.check-workflow-status-success.outcome }}
-
-    - name: check-workflow-status non-existent-job
-      id: check-workflow-status-non-existent-job
-      uses: ./check-workflow-status
-      with:
-        jobs: 'test-update-major-version-tag,non-existent-job'
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      continue-on-error: true
-
-    - name: Assert Workflow Status
-      uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
-      with:
-        expected: failure
-        actual: ${{ steps.check-workflow-status-non-existent-job.outcome }}
+        actual: ${{ steps.check-workflow-status-integration.outcome }}
 
     - name: failing-job
       id: failing-job
       continue-on-error: true
       run: exit 1
 
-    - name: check-workflow-status failed
+    - name: Test check-workflow-status detects failures
       id: check-workflow-status-failed
       uses: ./check-workflow-status
       with:
-        jobs: 'test-update-major-version-tag,failing-job'
         github-token: ${{ secrets.GITHUB_TOKEN }}
       continue-on-error: true
 
@@ -126,28 +109,37 @@ jobs:
         expected: failure
         actual: ${{ steps.check-workflow-status-failed.outcome }}
 
-    - name: check-workflow-status succeeds when no required files are present
-      id: check-workflow-status-required-files
+    - name: skipped-job
+      id: skipped-job
+      if: false
+      run: echo "This job should be skipped"
+
+    - name: Test check-workflow-status with skipped job (succeed=true)
+      id: check-workflow-status-skipped-succeed
       uses: ./check-workflow-status
       with:
-        jobs: 'failing-job'
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        requires-files-changed: this/does/not.exist,neither/**/does.this
-      continue-on-error: true
-    
-    - name: Assert workflow status (on PR)
+        skipped-jobs-succeed: true
+
+    - name: Assert Workflow Status (skipped allowed)
       uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
-      if: ${{ github.event_name == 'pull_request' }}
       with:
         expected: success
-        actual: ${{ steps.check-workflow-status-required-files.outcome }}
+        actual: ${{ steps.check-workflow-status-skipped-succeed.outcome }}
 
-    - name: Assert workflow status (on non-PR)
+    - name: Test check-workflow-status with skipped job (succeed=false)
+      id: check-workflow-status-skipped-fail
+      uses: ./check-workflow-status
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        skipped-jobs-succeed: false
+      continue-on-error: true
+
+    - name: Assert Workflow Status (skipped not allowed)
       uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
-      if: ${{ github.event_name != 'pull_request' }}
       with:
         expected: failure
-        actual: ${{ steps.check-workflow-status-required-files.outcome }}
+        actual: ${{ steps.check-workflow-status-skipped-fail.outcome }}
 
   test-commit-sha:
     runs-on: kubernetes-runner
@@ -184,5 +176,4 @@ jobs:
       id: check-workflow-status
       uses: ./check-workflow-status
       with:
-        jobs: 'test-update-major-version-tag,test-check-workflow-status,test-commit-sha'
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This repository contains common GitHub Actions and shared workflows.
 
 The following GitHub Actions are available in this repository:
 
-- [check-workflow-status](check-workflow-status/README.md)
 - [commit-sha](commit-sha/README.md)
+- [check-workflow-status](check-workflow-status/README.md)
 - [update-major-version-tag](update-major-version-tag/README.md)
 
 <!-- END ACTIONS -->

--- a/check-workflow-status/README.md
+++ b/check-workflow-status/README.md
@@ -10,16 +10,17 @@ This action requires a GitHub token with the following permissions:
   permissions:
     contents: read
     actions: read
-    pull-requests: read # Only needed if you use the `required-files-changed` input
 ```
 
 ## 🔧 Inputs
 
-|          Name          |                                                                  Description                                                                  |Required|Default|
-|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|--------|-------|
-|         `jobs`         |                                             Comma-separated list of job names to check status for.                                            |   Yes  |   ``  |
-|     `github-token`     |                                                   GitHub token to authenticate API requests.                                                  |   Yes  |       |
-|`requires-files-changed`|Comma-separated list of file paths or globs. If specified and this workflow runs on a PR with no matching files changed, it exits successfully.|   No   |   ``  |
+|          Name         |                                               Description                                               |Required|Default|
+|-----------------------|---------------------------------------------------------------------------------------------------------|--------|-------|
+|     `github-token`    |                                GitHub token to authenticate API requests.                               |   Yes  |       |
+|   `timeout-minutes`   |             Maximum time to wait for all jobs to complete (in minutes). Default: 30 minutes.            |   No   |  `30` |
+| `initial-wait-seconds`|       Time to wait for the first job to appear in the workflow (in seconds). Default: 10 seconds.       |   No   |  `10` |
+| `skipped-jobs-succeed`|Whether to treat skipped jobs as successful. Set to 'false' to fail if any job is skipped. Default: true.|   No   | `true`|
+|`poll-interval-seconds`|            Time between polling API for job status updates (in seconds). Default: 5 seconds.            |   No   |  `5`  |
 
 ## 📤 Outputs
 

--- a/check-workflow-status/action.yml
+++ b/check-workflow-status/action.yml
@@ -9,24 +9,33 @@ description: |
     permissions:
       contents: read
       actions: read
-      pull-requests: read # Only needed if you use the `required-files-changed` input
   ```
 author: EIDP
 inputs:
-  jobs:
-    description: >
-      Comma-separated list of job names to check status for.
-    required: true
-    default: ''
   github-token:
     description: >
       GitHub token to authenticate API requests.
     required: true
-  requires-files-changed:
+  timeout-minutes:
     description: >
-      Comma-separated list of file paths or globs. If specified and this workflow runs on a PR with no matching files changed, it exits successfully.
+      Maximum time to wait for all jobs to complete (in minutes). Default: 30 minutes.
     required: false
-    default: ''
+    default: '30'
+  initial-wait-seconds:
+    description: >
+      Time to wait for the first job to appear in the workflow (in seconds). Default: 10 seconds.
+    required: false
+    default: '10'
+  skipped-jobs-succeed:
+    description: >
+      Whether to treat skipped jobs as successful. Set to 'false' to fail if any job is skipped. Default: true.
+    required: false
+    default: 'true'
+  poll-interval-seconds:
+    description: >
+      Time between polling API for job status updates (in seconds). Default: 5 seconds.
+    required: false
+    default: '5'
 
 runs:
   using: composite
@@ -42,6 +51,8 @@ runs:
       run: |
         python3 "${{ github.action_path }}/check_status.py"
       env:
-        INPUT_JOBS: ${{ inputs.jobs }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
-        INPUT_REQUIRES_FILES_CHANGED: ${{ inputs.requires-files-changed }}
+        INPUT_TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+        INPUT_INITIAL_WAIT_SECONDS: ${{ inputs.initial-wait-seconds }}
+        INPUT_SKIPPED_JOBS_SUCCEED: ${{ inputs.skipped-jobs-succeed }}
+        INPUT_POLL_INTERVAL_SECONDS: ${{ inputs.poll-interval-seconds }}

--- a/check-workflow-status/test_check_status.py
+++ b/check-workflow-status/test_check_status.py
@@ -1,4 +1,4 @@
-# Unit test to make sure that check_status.py correctly handles requires_files_changed patterns
+# Unit tests for check_status.py
 import os
 import sys
 import json
@@ -6,58 +6,243 @@ import tempfile
 from unittest import mock
 import check_status
 
-pr_event = {
-    "number": 123,
-}
 
-def write_temp_json(data):
-    fd, path = tempfile.mkstemp(suffix=".json")
-    with os.fdopen(fd, "w") as f:
-        json.dump(data, f)
-    return path
-
-def mock_fetch_json(url, token):
-    # This will be overridden in each test
-    return {}
-
-def run_test(patterns, changed_files_list, should_match):
-    event_path = write_temp_json(pr_event)
-    
+# Test: Dynamic job discovery with multiple jobs
+def test_dynamic_job_discovery():
     def test_fetch_json(url, token):
-        if "pulls" in url and "files" in url:
-            return changed_files_list
-        elif "actions/runs" in url and "jobs" in url:
-            return {"jobs": [{"name": "dummy", "conclusion": "success"}]}
-        else:
-            return {}
+        if "actions/runs" in url and "jobs" in url:
+            return {"jobs": [
+                {"name": "check-workflow-status", "conclusion": None},
+                {"name": "build", "conclusion": "success"},
+                {"name": "test", "conclusion": "success"},
+                {"name": "lint", "conclusion": "success"}
+            ]}
+        return {}
 
     with mock.patch("check_status.fetch_json", side_effect=test_fetch_json):
-        result = check_status.check_status(
-            jobs=["dummy"],
-            github_token="dummy_token",
-            requires_files_changed=patterns,
-            event_name="pull_request",
-            repo="eidp/actions-common",
-            run_id="1",
-            event_path=event_path,
-        )
+        with mock.patch("time.sleep"):
+            result = check_status.check_status(
+                github_token="dummy_token",
+                repo="eidp/actions-common",
+                run_id="1",
+            )
 
-    os.unlink(event_path)
-    
-    if should_match:
-        assert result is True, f"Expected match (True), got {result}"
-    else:
-        assert result is True, f"Expected no match but successful exit (True), got {result}"
+    assert result is True, f"Expected all jobs to succeed, got {result}"
+
+
+# Test: Job appears dynamically during execution
+def test_dynamic_job_appearance():
+    call_count = [0]
+
+    def test_fetch_json(url, token):
+        if "actions/runs" in url and "jobs" in url:
+            call_count[0] += 1
+            # First call: only check-workflow-status job
+            if call_count[0] == 1:
+                return {"jobs": [
+                    {"name": "check-workflow-status", "conclusion": None},
+                ]}
+            # Second call: test job appears
+            elif call_count[0] == 2:
+                return {"jobs": [
+                    {"name": "check-workflow-status", "conclusion": None},
+                    {"name": "test", "conclusion": None},
+                ]}
+            # Third call: test job completes
+            else:
+                return {"jobs": [
+                    {"name": "check-workflow-status", "conclusion": None},
+                    {"name": "test", "conclusion": "success"},
+                ]}
+        return {}
+
+    with mock.patch("check_status.fetch_json", side_effect=test_fetch_json):
+        with mock.patch("time.sleep"):
+            result = check_status.check_status(
+                github_token="dummy_token",
+                repo="eidp/actions-common",
+                run_id="1",
+            )
+
+    assert result is True, f"Expected job to be discovered and succeed, got {result}"
+
+
+# Test: Current job is excluded from checks
+def test_current_job_excluded():
+    def test_fetch_json(url, token):
+        if "actions/runs" in url and "jobs" in url:
+            return {"jobs": [
+                {"name": "check-workflow-status", "conclusion": None},  # This is the current job
+                {"name": "test", "conclusion": "success"},
+            ]}
+        return {}
+
+    with mock.patch("check_status.fetch_json", side_effect=test_fetch_json):
+        with mock.patch("time.sleep"):
+            result = check_status.check_status(
+                github_token="dummy_token",
+                repo="eidp/actions-common",
+                run_id="1",
+            )
+
+    assert result is True, f"Expected success (current job excluded), got {result}"
+
+
+# Test: Skipped jobs with skipped_jobs_succeed=True
+def test_skipped_jobs_succeed_true():
+    def test_fetch_json(url, token):
+        if "actions/runs" in url and "jobs" in url:
+            return {"jobs": [
+                {"name": "check-workflow-status", "conclusion": None},
+                {"name": "test", "conclusion": "skipped"},
+            ]}
+        return {}
+
+    with mock.patch("check_status.fetch_json", side_effect=test_fetch_json):
+        with mock.patch("time.sleep"):
+            result = check_status.check_status(
+                github_token="dummy_token",
+                repo="eidp/actions-common",
+                run_id="1",
+            )
+
+    assert result is True, f"Expected skipped job to succeed, got {result}"
+
+
+# Test: Skipped jobs with skipped_jobs_succeed=False
+def test_skipped_jobs_succeed_false():
+    def test_fetch_json(url, token):
+        if "actions/runs" in url and "jobs" in url:
+            return {"jobs": [
+                {"name": "check-workflow-status", "conclusion": None},
+                {"name": "test", "conclusion": "skipped"},
+            ]}
+        return {}
+
+    with mock.patch("check_status.fetch_json", side_effect=test_fetch_json):
+        with mock.patch("time.sleep"):
+            result = check_status.check_status(
+                github_token="dummy_token",
+                repo="eidp/actions-common",
+                run_id="1",
+                skipped_jobs_succeed=False,
+            )
+
+    assert result is False, f"Expected skipped job to fail, got {result}"
+
+
+# Test: Job failure causes immediate failure
+def test_job_failure_immediate():
+    def test_fetch_json(url, token):
+        if "actions/runs" in url and "jobs" in url:
+            return {"jobs": [
+                {"name": "check-workflow-status", "conclusion": None},
+                {"name": "test", "conclusion": "failure"},
+                {"name": "build", "conclusion": None},  # Still in progress
+            ]}
+        return {}
+
+    with mock.patch("check_status.fetch_json", side_effect=test_fetch_json):
+        with mock.patch("time.sleep"):
+            result = check_status.check_status(
+                github_token="dummy_token",
+                repo="eidp/actions-common",
+                run_id="1",
+            )
+
+    assert result is False, f"Expected failure due to failed job, got {result}"
+
+
+# Test: Overall timeout exceeded
+def test_overall_timeout():
+    def test_fetch_json(url, token):
+        if "actions/runs" in url and "jobs" in url:
+            return {"jobs": [
+                {"name": "check-workflow-status", "conclusion": None},
+                {"name": "test", "conclusion": None},  # Never completes
+            ]}
+        return {}
+
+    # Mock time to simulate timeout
+    start_time = 1000.0
+    elapsed = [0]
+
+    def mock_time():
+        return start_time + elapsed[0]
+
+    def mock_sleep(seconds):
+        elapsed[0] += 60  # Fast-forward by 1 minute each sleep
+
+    with mock.patch("check_status.fetch_json", side_effect=test_fetch_json):
+        with mock.patch("time.time", side_effect=mock_time):
+            with mock.patch("time.sleep", side_effect=mock_sleep):
+                result = check_status.check_status(
+                    github_token="dummy_token",
+                    repo="eidp/actions-common",
+                    run_id="1",
+                    timeout_minutes=1,
+                )
+
+    assert result is False, f"Expected timeout failure, got {result}"
+
+
+# Test: No jobs found after initial wait
+def test_no_jobs_found():
+    def test_fetch_json(url, token):
+        if "actions/runs" in url and "jobs" in url:
+            return {"jobs": [
+                {"name": "check-workflow-status", "conclusion": None},  # Only current job
+            ]}
+        return {}
+
+    # Mock time for initial wait
+    start_time = 1000.0
+    elapsed = [0]
+
+    def mock_time():
+        return start_time + elapsed[0]
+
+    def mock_sleep(seconds):
+        elapsed[0] += seconds
+
+    with mock.patch("check_status.fetch_json", side_effect=test_fetch_json):
+        with mock.patch("time.time", side_effect=mock_time):
+            with mock.patch("time.sleep", side_effect=mock_sleep):
+                result = check_status.check_status(
+                    github_token="dummy_token",
+                    repo="eidp/actions-common",
+                    run_id="1",
+                    initial_wait_seconds=2,
+                )
+
+    assert result is False, f"Expected failure (no jobs found), got {result}"
+
 
 def main():
-    # Should match: pattern matches a file
-    run_test("src/foo/*.py", [{"filename": "src/foo/bar.py"}], True)
-    # Should not match: pattern does not match any file
-    run_test("src/baz/*.py", [{"filename": "src/foo/bar.py"}], False)
-    # Should match: multiple patterns, one matches
-    run_test("src/baz/*.py,src/foo/*.py", [{"filename": "src/foo/bar.py"}], True)
-    # Should not match: multiple patterns, none match
-    run_test("src/baz/*.py,docs/*.txt", [{"filename": "src/foo/bar.py"}], False)
+    print("Testing dynamic job discovery...")
+    test_dynamic_job_discovery()
+
+    print("Testing dynamic job appearance...")
+    test_dynamic_job_appearance()
+
+    print("Testing current job exclusion...")
+    test_current_job_excluded()
+
+    print("Testing skipped jobs (succeed=true)...")
+    test_skipped_jobs_succeed_true()
+
+    print("Testing skipped jobs (succeed=false)...")
+    test_skipped_jobs_succeed_false()
+
+    print("Testing job failure...")
+    test_job_failure_immediate()
+
+    print("Testing overall timeout...")
+    test_overall_timeout()
+
+    print("Testing no jobs found...")
+    test_no_jobs_found()
+
     print("All tests passed.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
This changes the approach `check-workflow-status` makes. Instead of receiving a static list of jobs, it instead dynamically waits for jobs to appear in its workflow and assumes that all must be completed.