### PR TITLE
chore(renovate): pin Renovate version and limit update PRs to weekly

### DIFF
--- a/.github/workflows/_renovate.yml
+++ b/.github/workflows/_renovate.yml
@@ -26,6 +26,7 @@ jobs:
       uses: ./renovate
       with:
         renovate-image: "cr.eidp.io/docker/renovate/renovate"
+        renovate-version: "43.170.0"
         github-app-id: ${{ secrets.DEP_MANAGER_GITHUB_APP_ID }}
         github-app-pem: ${{ secrets.DEP_MANAGER_GITHUB_APP_PEM_FILE }}
         all-secrets: ${{ toJSON(secrets) }}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,26 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>eidp/renovate-config"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/_renovate\\.yml$/"],
+      "matchStrings": [
+        "renovate-version:\\s*[\"'](?<currentValue>[^\"']+)[\"']"
+      ],
+      "depNameTemplate": "ghcr.io/renovatebot/renovate",
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "renovatebot/github-action",
+        "ghcr.io/renovatebot/renovate"
+      ],
+      "groupName": "Renovate",
+      "schedule": ["before 4am on monday"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Pin `renovate-version` to `43.170.0` in `.github/workflows/_renovate.yml` so the Renovate Docker image is no longer floating on the latest tag.
- Add a custom regex manager in `renovate.json` so Renovate keeps that pin current under the weekly schedule below.
- Group `renovatebot/github-action` and the Renovate Docker image into a single PR scheduled for `before 4am on monday`, capping Renovate-related update noise at one PR per week.

## Test plan
- [ ] Renovate dry-run picks up the `renovate-version` line and treats it as `ghcr.io/renovatebot/renovate` from the docker datasource.
- [ ] Next scheduled Renovate run only opens a single grouped "Renovate" PR (or none) for renovate-related dependencies.
- [ ] Confirm `cr.eidp.io/docker/renovate/renovate` mirror has the pinned `43.170.0` tag available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)