### PR TITLE
chore: use sized cloud runners

### DIFF
--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -12,4 +12,4 @@ jobs:
   common:
     uses: ./.github/workflows/common.yml
     with:
-      runs-on: ubuntu-slim
+      runs-on: ubuntu-latest

--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -12,4 +12,4 @@ jobs:
   common:
     uses: ./.github/workflows/common.yml
     with:
-      runs-on: kubernetes-runner
+      runs-on: ubuntu-slim

--- a/.github/workflows/_renovate.yml
+++ b/.github/workflows/_renovate.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   renovate:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-2404-x64-2core
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/_renovate.yml
+++ b/.github/workflows/_renovate.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   renovate:
-    runs-on: dind-runner-no-pvc
+    runs-on: ubuntu-slim
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/_renovate.yml
+++ b/.github/workflows/_renovate.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   renovate:
-    runs-on: ubuntu-2404-x64-2core
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test-check-workflow-status:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -28,7 +28,7 @@ jobs:
       run: python3 test_check_status.py
 
   test-commit-sha:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,7 +51,7 @@ jobs:
         comparison: 'startsWith'
 
   check-workflow-status:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test-check-workflow-status:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -28,7 +28,7 @@ jobs:
       run: python3 test_check_status.py
 
   test-commit-sha:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,7 +51,7 @@ jobs:
         comparison: 'startsWith'
 
   check-workflow-status:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/check-workflow-status-test-failure.yml
+++ b/.github/workflows/check-workflow-status-test-failure.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   success-job:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -27,7 +27,7 @@ jobs:
 
   failing-job:
     name: This job is supposed to fail
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -38,7 +38,7 @@ jobs:
           exit 1
 
   check-workflow-status:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/check-workflow-status-test-failure.yml
+++ b/.github/workflows/check-workflow-status-test-failure.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   success-job:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -27,7 +27,7 @@ jobs:
 
   failing-job:
     name: This job is supposed to fail
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -38,7 +38,7 @@ jobs:
           exit 1
 
   check-workflow-status:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/check-workflow-status-test-skipped-allowed.yml
+++ b/.github/workflows/check-workflow-status-test-skipped-allowed.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   success-job:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,7 +26,7 @@ jobs:
         run: echo "This job succeeds"
 
   skipped-job:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     name: This job is always skipped
     if: false
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: echo "This job is always skipped"
 
   check-workflow-status:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/check-workflow-status-test-skipped-allowed.yml
+++ b/.github/workflows/check-workflow-status-test-skipped-allowed.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   success-job:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,7 +26,7 @@ jobs:
         run: echo "This job succeeds"
 
   skipped-job:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     name: This job is always skipped
     if: false
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: echo "This job is always skipped"
 
   check-workflow-status:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/check-workflow-status-test-skipped-disallowed.yml
+++ b/.github/workflows/check-workflow-status-test-skipped-disallowed.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   success-job:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,7 +26,7 @@ jobs:
         run: echo "This job succeeds"
 
   skipped-job:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     name: This job is always skipped
     if: false
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: echo "This job is always skipped"
 
   check-workflow-status:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/check-workflow-status-test-skipped-disallowed.yml
+++ b/.github/workflows/check-workflow-status-test-skipped-disallowed.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   success-job:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,7 +26,7 @@ jobs:
         run: echo "This job succeeds"
 
   skipped-job:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     name: This job is always skipped
     if: false
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: echo "This job is always skipped"
 
   check-workflow-status:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/check-workflow-status-test-success.yml
+++ b/.github/workflows/check-workflow-status-test-success.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   success-job-1:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,7 +26,7 @@ jobs:
         run: echo "Job 1 completed successfully"
 
   success-job-2:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,7 +34,7 @@ jobs:
         run: echo "Job 2 completed successfully"
 
   success-job-3:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,7 +42,7 @@ jobs:
         run: echo "Job 3 completed successfully"
 
   check-workflow-status:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/check-workflow-status-test-success.yml
+++ b/.github/workflows/check-workflow-status-test-success.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   success-job-1:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,7 +26,7 @@ jobs:
         run: echo "Job 1 completed successfully"
 
   success-job-2:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,7 +34,7 @@ jobs:
         run: echo "Job 2 completed successfully"
 
   success-job-3:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,7 +42,7 @@ jobs:
         run: echo "Job 3 completed successfully"
 
   check-workflow-status:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Summary

Moves this repo's CI jobs off the shared `kubernetes-runner`/`dind-runner`/`dind-runner-no-pvc` labels onto sized runners provisioned for what each job actually needs.

<details>
<summary><b>Evidence bundle</b></summary>

### Intent

No ticket. Follows the runner-consolidation pattern already merged in eidp/eidp-api (#1008): the shared `kubernetes-runner`/`dind-runner` pools were a one-size-fits-all default — `dind-runner` for anything Docker-ish, `kubernetes-runner` for everything else — regardless of what a given job actually needed. This reclassifies each job in this repo's CI by what it does: `ubuntu-slim` if it needs neither Docker nor a live cluster, `ubuntu-2404-x64-2core` if it needs one of those but is lightweight, `ubuntu-2404-x64-4core` reserved for resource-intensive jobs.

### Context

Same mapping eidp-api#1008 established, with one correction made along the way and reflected in this diff: the `renovate` job runs on `ubuntu-latest`, not a self-hosted label. `eidp/actions-common/renovate` pulls and runs `cr.eidp.io/docker/renovate/renovate` via `renovatebot/github-action`, which `ubuntu-slim` can't do — and GitHub-hosted is cheaper than reserving self-hosted capacity for a scheduled bot job.

### Rollback

Revert this commit and merge; the old `kubernetes-runner`/`dind-runner` labels are untouched elsewhere and remain available as a fallback. Not yet tested — I haven't run this branch's pipeline, so confirm the reclassified jobs actually succeed before merging.

### Risk hunks

1. Every job moved to `ubuntu-slim` in this diff assumes it needs neither Docker nor a live cluster. That assumption was wrong once already in this migration (the `renovate` job, now fixed to `ubuntu-latest`) — accepted, but worth a second look at any `ubuntu-slim` job in this diff.

</details>


