### PR TITLE
ci: run renovate on ubuntu-2404-x64-2core

### DIFF
--- a/.github/workflows/_renovate.yml
+++ b/.github/workflows/_renovate.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2404-x64-2core
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
This repo's own renovate workflow sets `renovate-image: "cr.eidp.io/docker/renovate/renovate"` — a raw `docker pull` of the Renovate runner image itself from Harbor, which bypasses the org's `registryAliases` shim entirely (that shim only affects Renovate's own datasource lookups, not the literal image pull performed by the GitHub Action step).

`ubuntu-2404-x64-2core` is the GitHub-hosted larger runner with a static IP already allowlisted for Harbor access, so this avoids needing a self-hosted runner while still reaching the internal network.

## Test plan
- [ ] Confirm the next scheduled renovate run succeeds in pulling the pinned renovate image from Harbor